### PR TITLE
ITS 2.0 output

### DIFF
--- a/dbpedia-spotlight-0.3.js
+++ b/dbpedia-spotlight-0.3.js
@@ -96,9 +96,9 @@ function sortOffset(a,b){
        getAnnotatedText: function(response) {
             var json;
             if (typeof response=='object') {
-		json = response
+		json = response;
 	    } else {
-		json = $.parseJSON(response.toString());
+		json = $.parseJSON(response);
 	    }
 
            var text = json["annotation"]["@text"];
@@ -142,7 +142,7 @@ function sortOffset(a,b){
             if (typeof response=='object') {
 		json = response;
 	    } else {
-		json = $.parseJSON(response.toString());
+		json = $.parseJSON(response);
 	    }
 
             var text = json["@text"];
@@ -197,7 +197,7 @@ function sortOffset(a,b){
             if (typeof response=='object') {
 		json = response;
 	    } else {
-		json = $.parseJSON(response.toString());
+		json = $.parseJSON(response);
 	    }
             var text = json["@text"];
 
@@ -241,7 +241,7 @@ function sortOffset(a,b){
              if (typeof response=='object') {
 	 	json = response;
 	     } else {
-	 	json = $.parseJSON(response.toString());
+	 	json = $.parseJSON(response);
 	     }
              var suggestions = "";
 	     if (json.annotation['surfaceForm']!=undefined) {                  
@@ -332,6 +332,7 @@ function sortOffset(a,b){
 		//init(options);
                function update(response) { 
                    var content = "<div>" + Parser.getAnnotatedText(response) + "</div>";
+		
                    if (settings.powered_by == 'yes') { 
                        $(content).append($(powered_by)); 
                    };                        

--- a/dbpedia-spotlight-0.3.js
+++ b/dbpedia-spotlight-0.3.js
@@ -157,7 +157,7 @@ function sortOffset(a,b){
                 var uri = e["@URI"];
 
                 var sfLength = parseInt(sfName.length);
-                var snippet = text.substring(start, offset)
+                var snippet = text.substring(start, offset);
                 var surfaceForm = text.substring(offset,offset+sfLength);
                 start = offset+sfLength;
 
@@ -176,6 +176,47 @@ function sortOffset(a,b){
 
                 snippet += "</a>";
 
+                return snippet;
+            }).join("");
+            //snippet after last surface form
+            annotatedText += text.substring(start, text.length);
+            //console.log(annotatedText);
+            return annotatedText.replace(/\n/g, "<br />\n");
+        },
+
+	getAnnotatedTextFirstBestITS: function(response) {
+            var json = $.parseJSON(response);
+            if (json==null) json = response; // when it comes already parsed
+
+            var text = json["@text"];
+
+            var start = 0;
+            var annotatedText = text;
+
+            var annotations = new Array();
+            if (json['Resources']!=undefined) {
+                annotations = annotations.concat(json['Resources']); // deals with the case of only one surfaceFrom returned (ends up not being an array)
+            } else {
+                //TODO show a message saying that no annotations were found
+            }
+
+            annotatedText = annotations.map(function(e) {
+                if (e==undefined) return "";
+
+                var sfName = e["@surfaceForm"];
+                var offset = parseInt(e["@offset"]);
+                var uri = e["@URI"];
+
+                var sfLength = parseInt(sfName.length);
+                var snippet = text.substring(start, offset);
+                start = offset+sfLength;
+
+                var support = parseInt(e["@support"]);
+
+		snippet += "<span id='" + (sfName+offset) +
+			"' its-ta-ident-ref='" + uri +
+			"' its-ta-confidence='" + parseFloat(e["@similarityScore"]).toPrecision(3) + "'>" + sfName
+                snippet += "</span>";
                 return snippet;
             }).join("");
             //snippet after last surface form

--- a/dbpedia-spotlight-0.3.js
+++ b/dbpedia-spotlight-0.3.js
@@ -94,8 +94,12 @@ function sortOffset(a,b){
              return ul;
         },
        getAnnotatedText: function(response) {
-           var json = $.parseJSON(response);
-           if (json==null) json = response; // when it comes already parsed
+            var json;
+            if (typeof response=='object') {
+		json = response
+	    } else {
+		json = $.parseJSON(response.toString());
+	    }
 
            var text = json["annotation"]["@text"];
 
@@ -134,8 +138,12 @@ function sortOffset(a,b){
            return annotatedText.replace(/\n/g, "<br />\n");
        },
         getAnnotatedTextFirstBest: function(response) {
-            var json = $.parseJSON(response);
-            if (json==null) json = response; // when it comes already parsed
+            var json;
+            if (typeof response=='object') {
+		json = response;
+	    } else {
+		json = $.parseJSON(response.toString());
+	    }
 
             var text = json["@text"];
 
@@ -185,9 +193,12 @@ function sortOffset(a,b){
         },
 
 	getAnnotatedTextFirstBestITS: function(response) {
-            var json = $.parseJSON(response);
-            if (json==null) json = response; // when it comes already parsed
-
+            var json;
+            if (typeof response=='object') {
+		json = response;
+	    } else {
+		json = $.parseJSON(response.toString());
+	    }
             var text = json["@text"];
 
             var start = 0;
@@ -226,8 +237,12 @@ function sortOffset(a,b){
         },
 
 	getSuggestions: function(response, targetSurfaceForm) {
-             var json = $.parseJSON(response);
-	     if (json==null) json = response; // when it comes already parsed
+             var json;
+             if (typeof response=='object') {
+	 	json = response;
+	     } else {
+	 	json = $.parseJSON(response.toString());
+	     }
              var suggestions = "";
 	     if (json.annotation['surfaceForm']!=undefined) {                  
                   var annotations = new Array().concat(json.annotation.surfaceForm) // deals with the case of only one surfaceFrom returned (ends up not being an array)

--- a/dbpedia-spotlight-0.3.js
+++ b/dbpedia-spotlight-0.3.js
@@ -296,6 +296,38 @@ function sortOffset(a,b){
                     });    
                  });
        },
+       bestITS: function( options ) {
+          //init(options);
+          function update(response) { 
+
+                   var content = "<div>" + Parser.getAnnotatedTextFirstBestITS(response) + "</div>";
+                   if (settings.powered_by == 'yes') {
+                       $(content).append($(powered_by));
+                   };
+                   $(this).html(content);
+
+               if(settings.callback != undefined) {
+                   settings.callback(response);
+               }
+          }    
+       
+               return this.each(function() {            
+                 //console.log($.quoteString($(this).text()));
+                 var params = {'text': $(this).text(), 'confidence': settings.confidence, 'support': settings.support, 'spotter': settings.spotter, 'disambiguator': settings.disambiguator, 'policy': settings.policy };
+                 if("types" in settings && settings["types"] != undefined)
+                   params["types"] = settings.types;
+                 if("sparql" in settings && settings["sparql"] != undefined)
+                   params["sparql"] = settings.sparql;
+    
+                 ajaxRequest = $.ajax({ 'url': settings.endpoint+"/annotate",
+                      'data': params,
+                      'context': this,
+                      'headers': {'Accept': 'application/json'},
+                      'success': update,
+                      'error': function(response) { if(settings.callback != undefined) { settings.callback(response); } }
+                    });    
+                 });
+       },
        candidates: function( options ) {
 		//init(options);
                function update(response) { 


### PR DESCRIPTION
Hi,

I was searching for a way to get some text annotated in ITS 2.0 format with DBpedia Spotlight. I'm not sure if this is the location to add this but I got it running with some simple HTML:

``` html
<!DOCTYPE html>
<html><head><title>Example</title>
<style>span {background-color:#AAAAAA}</style>
<script src="http://code.jquery.com/jquery-2.2.1.min.js"></script>
<script src="http://athalhammer.github.io/demo/dbpedia-spotlight-0.3.js"></script>
<script>
$(document).ready(function() {
    var select = ".annotate";
    var settings = {
        "endpoint" : "http://spotlight.sztaki.hu:2222/rest",
        "spotter"  : "Default",
        "its"      : "yes"
    };
    $(select).annotate(settings);
    $(select).annotate("best");      
});
</script>
</head>
<body><div class="annotate">Angela Merkel is TIME Person of the Year 2015.</div></body>
</html>
```

Kind regards,
Andreas
